### PR TITLE
Update build.yml -fix url for AppRun-x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
 
           # Download AppRun (runtime for the AppImage)
           # Using a specific release tag for stability
-          curl --location -o build/calibre.AppDir/AppRun https://github.com/AppImage/appimagetool/releases/download/continuous/AppRun-x86_64
+          curl --location -o build/calibre.AppDir/AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64
           chmod +x build/calibre.AppDir/AppRun
 
           # Create the usr/bin directory inside the AppDir


### PR DESCRIPTION
The currently set url to AppRun-x86_64 isn't working. I replaced it with a working one, it's not building a working appimage again